### PR TITLE
Allows to use uppercase margin letters in laye's name

### DIFF
--- a/Compo.sketchplugin/Contents/Sketch/Compo.cocoascript
+++ b/Compo.sketchplugin/Contents/Sketch/Compo.cocoascript
@@ -217,6 +217,9 @@ function resizeBackground(backgroundLayer, masterLayer) {
  */
 
 function getMarginsFromName(name) {
+
+  name = name.toLowerCase();
+
   var margins = {
     top:    undefined,
     right:  undefined,


### PR DESCRIPTION
Problem: Layers margin letters must be lowercase
Solution: Add toLowerCase() function to 'normalize' margin letters
